### PR TITLE
Adds basic documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,58 @@
 # wagtailrelated
 
 A module for Wagtail that finds related pages and tags for your pages.
+
+## How to install
+
+Install using pip:
+
+```
+pip install wagtail-related
+```
+
+
+### Settings
+
+In your settings file, add `wagtailrelated` to `INSTALLED_APPS`:
+
+```python
+INSTALLED_APPS = [
+    # ...
+    'wagtailrelated',
+    # ...
+]
+```
+
+### URL configuration
+
+Include API url into your `urlpatterns`:
+
+```python
+urlpatterns = [
+    # ...
+    url(r'^api/more-like-this', include('wagtailrelated.api.urls')),
+    # ...
+```
+
+### Backend settings
+
+Add the following setting into your project:
+
+```python
+WAGTAIL_RELATED_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtailrelated.backends.elasticsearch5',
+    }
+}
+```
+
+Note that the module uses Elasticsearch to find related pages and relies on Wagtail's
+built-in search backend. This means that you should have the
+[`WAGTAILSEARCH_BACKENDS` setting](http://docs.wagtail.io/en/v2.1/topics/search/backends.html#elasticsearch-backend)
+comfigured with `wagtail.search.backends.elasticsearch5` in your project.
+
+Settings shown in this insturction will work fine,
+if your Elasticsearch 5 backend exists under the `default` key.
+If your project has multiple Wagtail search backends and your Elasticsearch 5 search backend
+has different key, see how you need to modify `WAGTAIL_RELATED_BACKENDS`
+[here](./docs/related_backends.md#set-up-wagtail_related_backends-use-non-default-search-backend).

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ if your Elasticsearch 5 backend exists under the `default` key.
 If your project has multiple Wagtail search backends and your Elasticsearch 5 search backend
 has different key, see how you need to modify `WAGTAIL_RELATED_BACKENDS`
 [here](./docs/related_backends.md#set-up-wagtail_related_backends-use-non-default-search-backend).
+
+## How to use
+
+The package provides an API to get related pages. See the
+[API documentation](./docs/api.md).

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,87 @@
+# More Like This API
+
+## Request
+
+`/api/more-like-this/?id=<page_id>&limit=<max items>&exclude=<exclusion list>`
+
+* `id` - Required. The id of the source Wagtail Page. This will typically be the current page.
+* `limit` - the maximum number of results to return. Default = `10`.
+* `type` - a comma-separated list of Django content types.
+  Each type must be a subclass of `wagtailcore.Page` (which is a default value).
+* `exclusion list` - a comma-separated list of Wagtail Page IDs which should not included in results
+
+
+### Examples
+
+* `/api/more-like-this/?id=42&limit=5type=shops.ShopsHomePage&exclude=19,532,4`
+* `/api/more-like-this/?id=42`
+
+
+## Response
+
+```json
+[
+  {
+    "url": "https://example.com/path/page",
+    "title": "2D: Drawing Studios",
+    "score": 0.8,
+    "type": "shops.ShopsHomePage"
+  },
+  {
+    "url": "https://example.com/path/other-page",
+    "title": "rawing",
+    "score": 0.75,
+    "type": "campusblog.CampusBlogPage"
+  },
+  {
+    "url": "https://example.com/path/something-else",
+    "title": "3D Printer Services",
+    "score": 0.7,
+    "type": "shops.ShopsHomePage"
+  },
+]
+```
+
+
+### Errors
+
+Error response example:
+
+```json
+{
+    "detail": "The ID does not match a live page"
+}
+```
+
+The API will return an error in the following cases:
+
+* No ID is provided
+* The ID does not match a live page
+* `limit` is more than 50 or less than 1
+* `type` invalid type. Must be a subclass of `wagtailcore.Page`
+* `exclude` is not a list of integers
+    * integers which do not match live pages will be silently ignored
+
+
+## Notes
+
+In the initial version of the package, we will be using all text fields
+to find similar pages. It’s possible to
+[limit fields](https://www.elastic.co/guide/en/elasticsearch/reference/5.3/query-dsl-mlt-query.html#_document_input_parameters)
+that should be used for matching, but it will be tricky
+for queries where we ask for multiple content types,
+because search content type has own fields. We suggest not to
+include this feature in the initial version for simplicity.
+We will be able to add this feature later, if we see a need
+(for example, results are not relevant enough without limiting fields).
+
+There is also no option to specify min score / threshold
+in the API, but results will be returned in the order of relevance:
+most relevant items will be in the beginning of a list. So the client has few options:
+
+* Take top N elements from the list (or simply specify `limit` to be equal to N)
+* Request N relevant pages and calculate “minimum relevance” using returned scores.
+  Example logic: display all related pages with the
+  score `doc_score >= max_score / 100 * percent`. This option is rarely useful,
+  because it’s possible to get scores like `[100, 5, 3, 1]`.
+  So if your `percent` is 90% you will only get one item with the score `100` .

--- a/docs/related_backends.md
+++ b/docs/related_backends.md
@@ -1,0 +1,44 @@
+# Related backends
+
+This document describes possible configuration options and back-end specific features.
+
+## Elasticsearch 5 backend
+
+
+### Set up `WAGTAIL_RELATED_BACKENDS` use non-`default` search backend
+
+Some projects have multiple search backends and it's possible
+that the Elasticsearch 5 search backend you want to use has a key other than `default`
+in `WAGTAIL_RELATED_BACKENDS`. It's possible to change `WAGTAIL_RELATED_BACKENDS` to reflect it.
+
+Here is an example of `WAGTAILSEARCH_BACKENDS`:
+
+```python
+WAGTAILSEARCH_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtail.contrib.postgres_search.backend',
+    },
+    'elasticsearch_key': {
+        'BACKEND': 'wagtail.search.backends.elasticsearch5',
+        # Other ES search back-end parameters like URLS, INDEX, etc
+    },
+}
+```
+
+In this case, you need to add the `wagtailsearch_backend` parameter to your
+related backend definition like this:
+
+```python
+WAGTAIL_RELATED_BACKENDS = {
+    'default': {
+        'BACKEND': 'wagtailrelated.backends.elasticsearch5',
+        'wagtailsearch_backend': 'elasticsearch_key',
+    }
+}
+```
+
+### How Elasticsearch related backend works
+
+Under the hood the backend uses the
+[`more_like_this` query](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/query-dsl-mlt-query.html).
+Currently it uses all text fields to find similar docuemnts. It is possible that we will change this behaviour.


### PR DESCRIPTION
[Rendered version](https://github.com/torchbox/wagtail-related/blob/docs_install/README.md)

Note that the package currently is not pip installable, so `pip install wagtail-related` will not work. We need to publish the package before merging docs.